### PR TITLE
Add conda activate command to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tools for analyzing Slay the Spire.
 # Install conda. I'll leave that to another guide, but I used Python 3.7 / 3.8 and miniconda.
 # First create a conda environment:
 conda create --name snecko
+conda activate snecko
 
 # Install dependencies
 conda install -c pytorch -c fastai fastai


### PR DESCRIPTION
After creating a conda environment, if you don't activate it before installing dependencies, they'll be installed in the base conda env instead of the snecko one.  On mac at least.